### PR TITLE
Add source files to the gem.

### DIFF
--- a/hsluv.gemspec
+++ b/hsluv.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/hsluv/hsluv-ruby'
   spec.license       = 'MIT'
 
+  spec.files = Dir['lib/**/*']
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.8'


### PR DESCRIPTION
Currently, installing this gem simply yields an empty directory:

    $ gem install hsluv
    Successfully installed hsluv-1.0.0
    1 gem installed
    $ gem contents hsluv
    $

After:

    $ gem build hsluv.gemspec
    <snip>
    $ gem install hsluv
    Successfully installed hsluv-1.0.0
    1 gem installed
    $ gem contents hsluv
    $HOME/.gem/ruby/2.3.3/gems/hsluv-1.0.0/lib/hsluv.rb
    $